### PR TITLE
Use more then one cpu in qemu

### DIFF
--- a/t/config.py
+++ b/t/config.py
@@ -155,6 +155,7 @@ class DefaultsTestCase(unittest.TestCase):
         c.suite = 'potato'
         c.worker_suite = 'sarge'
         c.qemu_ram_size = '512M'
+        c.parallel = 1
         c.sbuild_worker_suite = 'alchemist'
         c.sbuild_worker_vendor = 'steamos'
         c.piuparts_worker_suite = 'scout'
@@ -178,7 +179,7 @@ class DefaultsTestCase(unittest.TestCase):
                 '{}/m68k/debian/sarge/autopkgtest.qcow2'.format(
                     c.storage))
         self.assertEqual(c.worker,
-                ['qemu', '--ram-size=512',
+                ['qemu', '--ram-size=512', '--cpus=1',
                     '{}/m68k/debian/sarge/autopkgtest.qcow2'.format(
                     c.storage)])
 
@@ -186,21 +187,21 @@ class DefaultsTestCase(unittest.TestCase):
                 '{}/m68k/steamrt/precise/autopkgtest.qcow2'.format(
                     c.storage))
         self.assertEqual(c.piuparts_worker,
-                ['qemu', '--ram-size=512',
+                ['qemu', '--ram-size=512', '--cpus=1',
                     '{}/m68k/steamrt/precise/autopkgtest.qcow2'.format(
                     c.storage)])
         self.assertEqual(c.sbuild_worker_qemu_image,
                 '{}/m68k/steamos/alchemist/autopkgtest.qcow2'.format(
                     c.storage))
         self.assertEqual(c.sbuild_worker,
-                ['qemu', '--ram-size=512',
+                ['qemu', '--ram-size=512', '--cpus=1',
                     '{}/m68k/steamos/alchemist/autopkgtest.qcow2'.format(
                     c.storage)])
         self.assertEqual(c.vmdebootstrap_worker_qemu_image,
                 '{}/m68k/ubuntu/xenial/autopkgtest.qcow2'.format(
                     c.storage))
         self.assertEqual(c.vmdebootstrap_worker,
-                ['qemu', '--ram-size=512',
+                ['qemu', '--ram-size=512', '--cpus=1',
                     '{}/m68k/ubuntu/xenial/autopkgtest.qcow2'.format(
                     c.storage)])
 

--- a/vectis/config.py
+++ b/vectis/config.py
@@ -897,6 +897,7 @@ class Config(_ConfigLike):
             if self.qemu_ram_size is not None:
                 value.append('--ram-size={}'.format(self.qemu_ram_size // _1M))
 
+            value.append('--cpus={}'.format(self.parallel))
             value.append(self.worker_qemu_image)
 
         return value
@@ -911,6 +912,7 @@ class Config(_ConfigLike):
             if self.qemu_ram_size is not None:
                 value.append('--ram-size={}'.format(self.qemu_ram_size // _1M))
 
+            value.append('--cpus={}'.format(self.parallel))
             value.append(self.lxc_worker_qemu_image)
 
         return value
@@ -925,6 +927,7 @@ class Config(_ConfigLike):
             if self.qemu_ram_size is not None:
                 value.append('--ram-size={}'.format(self.qemu_ram_size // _1M))
 
+            value.append('--cpus={}'.format(self.parallel))
             value.append(self.piuparts_worker_qemu_image)
 
         return value
@@ -939,6 +942,7 @@ class Config(_ConfigLike):
             if self.qemu_ram_size is not None:
                 value.append('--ram-size={}'.format(self.qemu_ram_size // _1M))
 
+            value.append('--cpus={}'.format(self.parallel))
             value.append(self.sbuild_worker_qemu_image)
 
         return value
@@ -970,6 +974,7 @@ class Config(_ConfigLike):
             if self.qemu_ram_size is not None:
                 value.append('--ram-size={}'.format(self.qemu_ram_size // _1M))
 
+            value.append('--cpus={}'.format(self.parallel))
             value.append(self.vmdebootstrap_worker_qemu_image)
 
         return value


### PR DESCRIPTION
While vectis did set the default parallel to the number of cpus, the
qemu workers were always run with the (default) of one cpu making the
parallelism rather pointless. Update the default qemu worker command to
configure a number of cpu equal to the configured parallel value.

Signed-off-by: Sjoerd Simons <sjoerd.simons@collabora.co.uk>